### PR TITLE
카메라 워킹이 이벤트지점을 정확하게 비추지 못하는 문제 해결

### DIFF
--- a/9TeamHB/Assets/_Game/Scripts/Camera/CameraManager.cs
+++ b/9TeamHB/Assets/_Game/Scripts/Camera/CameraManager.cs
@@ -113,7 +113,7 @@ public class CameraManager : MonoBehaviour
         vcamEvent.Follow = marker;
         vcamEvent.ForceCameraPosition(pos, vcamEvent.transform.rotation);
         vcamEvent.Priority = 100;
-        yield return null;
+        yield return new WaitForEndOfFrame();        
         // 게임 일시정지 이벤트
         yield return new WaitForSecondsRealtime(0.1f);
         Time.timeScale = 0f;
@@ -147,6 +147,10 @@ public class CameraManager : MonoBehaviour
         var confiner = vcamP1.GetComponent<CinemachineConfiner2D>();
         confiner.InvalidateBoundingShapeCache();
         confiner = vcamP2.GetComponent<CinemachineConfiner2D>();
+        confiner.InvalidateBoundingShapeCache();
+        confiner = vcamEvent.GetComponent<CinemachineConfiner2D>();
+        confiner.InvalidateBoundingShapeCache();
+        confiner = vcamStart.GetComponent<CinemachineConfiner2D>();
         confiner.InvalidateBoundingShapeCache();
     }
 


### PR DESCRIPTION
바운더리 재 캐싱이 일어나지 않아 이벤트지점을 비추지 못하던 문제 해결